### PR TITLE
PER-15

### DIFF
--- a/packages/core/src/auto-apply.ts
+++ b/packages/core/src/auto-apply.ts
@@ -250,6 +250,11 @@ async function saveAssets(
 		`${assetPath}/application-details.json`,
 		JSON.stringify(applicationDetails),
 	);
+
+	// Save the LaTeX resume to the database
+	await updateSession(userId, sessionId, {
+		generatedResumeLatex: latexResume,
+	});
 }
 
 async function updateSession(
@@ -447,6 +452,7 @@ export async function runWithUrl(
 
 		await updateSession(userId, sessionId, {
 			assetPath,
+			generatedResumeLatex: latexResume,
 		});
 
 		let completedForm: z.infer<typeof formCompleterSchema> | null = null;

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -68,6 +68,13 @@ export const useFetchResumePdf = () => {
 		apiClient.get(`/generated-resume?sessionId=${sessionId}`, "arraybuffer");
 };
 
+export const useFetchResumeLatex = () => {
+	const apiClient = useApiClient();
+
+	return (sessionId: GetSessionsResponse[number]["id"]): Promise<string> =>
+		apiClient.get(`/generated-resume-latex?sessionId=${sessionId}`, "text");
+};
+
 export const useUpdateAssetContent = (id: string) => {
 	const apiClient = useApiClient();
 	return async (content: string) => {

--- a/packages/frontend/src/components/ApplicationList.tsx
+++ b/packages/frontend/src/components/ApplicationList.tsx
@@ -21,6 +21,7 @@ import {
 	ClipboardList,
 	Download,
 	FileClock,
+	FileText,
 	FileUser,
 	Link2,
 	MoveDownLeft,
@@ -36,6 +37,7 @@ import { formatSmartDate } from "@/lib/date";
 import {
 	useDeleteSession,
 	useFetchResumePdf,
+	useFetchResumeLatex,
 	useFetchSessions,
 	useUpdateJobStatus,
 } from "../api";
@@ -54,6 +56,7 @@ const Skeleton = ({ className = "" }: { className?: string }) => (
 export default function ApplicationList() {
 	const fetchApplications = useFetchSessions();
 	const fetchResumePdf = useFetchResumePdf();
+	const fetchResumeLatex = useFetchResumeLatex();
 	const updateJobStatus = useUpdateJobStatus();
 	const deleteSession = useDeleteSession();
 	const queryClient = useQueryClient();
@@ -103,7 +106,7 @@ export default function ApplicationList() {
 	const handleAssetClick = useCallback(
 		async (
 			id: string,
-			type: "resume" | "cover-letter" | "answered-form" | "logs",
+			type: "resume" | "resume-latex" | "cover-letter" | "answered-form" | "logs",
 		) => {
 			const session = sessions.find((session) => session.id === id);
 
@@ -153,6 +156,23 @@ export default function ApplicationList() {
 
 					break;
 				}
+				case "resume-latex": {
+					const latexContent = await fetchResumeLatex(id);
+
+					setAsset({
+						id,
+						content: latexContent,
+						name: getResumeFileName(
+							session.personalInfo?.fullName ?? "",
+							session.companyInfo?.shortName ?? "",
+							session.jobInfo?.shortTitle ?? "",
+						).replace('.pdf', '.tex'),
+						source: "list",
+						type: "latex",
+					});
+
+					break;
+				}
 				case "logs":
 					setAsset({
 						id,
@@ -164,7 +184,7 @@ export default function ApplicationList() {
 					break;
 			}
 		},
-		[sessions, setAsset, fetchResumePdf],
+		[sessions, setAsset, fetchResumePdf, fetchResumeLatex],
 	);
 
 	const handleChangeJobStatus = useCallback(
@@ -304,16 +324,28 @@ export default function ApplicationList() {
 					}
 
 					return (
-						<div className="grid grid-cols-3 gap-2">
+						<div className="grid grid-cols-4 gap-2">
 							{session.assetPath && (
-								<Button
-									size="sm"
-									variant="ghost"
-									className="cursor-pointer hover:scale-125"
-									onClick={() => handleAssetClick(session.id, "resume")}
-								>
-									<FileUser />
-								</Button>
+								<>
+									<Button
+										size="sm"
+										variant="ghost"
+										className="cursor-pointer hover:scale-125"
+										onClick={() => handleAssetClick(session.id, "resume")}
+										title="View PDF Resume"
+									>
+										<FileUser />
+									</Button>
+									<Button
+										size="sm"
+										variant="ghost"
+										className="cursor-pointer hover:scale-125"
+										onClick={() => handleAssetClick(session.id, "resume-latex")}
+										title="View LaTeX Resume"
+									>
+										<FileText />
+									</Button>
+								</>
 							)}
 							{session.coverLetter && (
 								<Button


### PR DESCRIPTION
Fixes PER-15 by ensuring generated LaTeX resumes are saved to the database and accessible via a new API endpoint and updated UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7a68ebf-5fa6-49b7-bbb0-5c8dcc43d9a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7a68ebf-5fa6-49b7-bbb0-5c8dcc43d9a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to view and download the LaTeX version of a generated resume alongside the existing PDF option in the application list.
  * Introduced a public API endpoint to retrieve the LaTeX resume, returning a .tex file with appropriate headers.

* **Bug Fixes**
  * The LaTeX resume endpoint now returns a 404 error when the session is incomplete or the LaTeX content is unavailable, improving error clarity for clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->